### PR TITLE
Add check for process being defined.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ if ('undefined' === typeof FP_ENV) {
             || window.location.hostname === '127.0.0.1'
             || window.location.hostname === '');
 
-    if (process && process.env && process.env.NODE_ENV) {
+    if ('undefined' !== typeof process && process && process.env && process.env.NODE_ENV) {
         global.FP_ENV = process.env.NODE_ENV;
     } else if (window && !isLocalhost) {
         global.FP_ENV = 'production';


### PR DESCRIPTION
Fixes 'process not defined' error when using with GatsbyJS.

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

## Proposed Changes

1. Add check for nodejs `process` before using

